### PR TITLE
Feature/docs update 2025 08 21

### DIFF
--- a/contracts/granthubcontract.clar
+++ b/contracts/granthubcontract.clar
@@ -306,3 +306,38 @@
     (asserts! (or (is-eq new-type "quadratic") (is-eq new-type "weighted")) ERR_INVALID_PROPOSAL)
     (var-set voting-type new-type)
     (ok true)))
+
+;; read only functions
+
+(define-read-only (get-proposal (proposal-id uint))
+  (map-get? proposals proposal-id))
+
+(define-read-only (get-balance (user principal))
+  (default-to u0 (map-get? user-balances user)))
+
+(define-read-only (get-vote (proposal-id uint) (voter principal))
+  (map-get? proposal-votes {proposal-id: proposal-id, voter: voter}))
+
+(define-read-only (get-treasury-balance)
+  (var-get dao-treasury))
+
+(define-read-only (get-total-supply)
+  (var-get total-supply))
+
+(define-read-only (get-proposal-count)
+  (var-get proposal-counter))
+
+(define-read-only (get-milestone-verification (proposal-id uint) (milestone-id uint))
+  (map-get? milestone-verifications {proposal-id: proposal-id, milestone-id: milestone-id}))
+
+(define-read-only (get-escrow-balance (proposal-id uint))
+  (default-to u0 (map-get? proposal-escrow proposal-id)))
+
+(define-read-only (is-oracle-authorized (oracle principal))
+  (default-to false (map-get? authorized-oracles oracle)))
+
+(define-read-only (get-voting-type)
+  (var-get voting-type))
+
+(define-read-only (get-slashing-claim (proposal-id uint) (claimant principal))
+  (map-get? slashing-claims {proposal-id: proposal-id, claimant: claimant}))


### PR DESCRIPTION
Governance primitives:
governance-token (FT) and proposal-nft (NFT)
Storage for proposals, votes, escrow, oracle auth/verifications, slashing claims
Admin/treasury:
initialize(initial-supply)
mint-tokens(recipient, amount)
add-to-treasury(amount)
set-voting-type(new-type) supporting “quadratic” or “weighted”
Token ops:
transfer-tokens(recipient, amount) with internal balances
Proposal lifecycle:
submit-proposal(title, description, budget, milestones) with budget/milestone validation
vote-on-proposal(proposal-id, vote-yes) with voting power per model and one-vote-per-user
finalize-proposal(proposal-id) with quorum and approval thresholds, escrow allocation
Oracle + milestones:
authorize-oracle(oracle)
verify-milestone(proposal-id, milestone-id)
release-milestone-funds(proposal-id, milestone-id) with escrow release and completion detection
Slashing:
initiate-slashing(proposal-id, claim-amount)
execute-slashing(proposal-id, claimant) returning funds to dao-treasury and marking proposal slashed
Read-only getters:
get-proposal, get-balance, get-vote, get-treasury-balance, get-total-supply, get-proposal-count
get-milestone-verification, get-escrow-balance, is-oracle-authorized, get-voting-type, get-slashing-claim
Clarinet compliance fixes:
Replaced deprecated block-height with stacks-block-height
Removed recursive pow(); calculate-voting-power() now squares directly for quadratic mode